### PR TITLE
[INTG-2227] Create stub workflow

### DIFF
--- a/.github/workflows/build-protoc.yml
+++ b/.github/workflows/build-protoc.yml
@@ -1,0 +1,24 @@
+# yamllint disable rule:line-length
+---
+name: Build protoc
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Create release tag'
+        required: false
+        type: boolean
+
+jobs:
+  protoc:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0


### PR DESCRIPTION
This creates a stub workflow so that I can start testing my workflow on my PR https://github.com/SafetyCulture/protoc-docker/pull/91.

The workflow cannot be triggered until it is in the `main` branch :(