### PR TITLE
[ATS-3165] Update Connect-Web package name

### DIFF
--- a/protoc-node/Dockerfile
+++ b/protoc-node/Dockerfile
@@ -3,4 +3,4 @@ LABEL maintainer="SafetyCulture <info@safetyculture.io>"
 
 RUN apk add --no-cache npm
 
-RUN npm install -g ts-protoc-gen @bufbuild/protoc-gen-es @bufbuild/protoc-gen-connect-web
+RUN npm install -g ts-protoc-gen @bufbuild/protoc-gen-es @bufbuild/protoc-gen-connect-es


### PR DESCRIPTION
The Connect-Web team have renamed `protoc-gen-connect-web` to protoc-gen-connect-es` [in v0.8.0](https://github.com/bufbuild/connect-es/releases), so this PR updates this so it will be pulled correctly in APISchema.