### PR TITLE
ENP-2825: Name workflow run after selected image

### DIFF
--- a/.github/workflows/build-protoc.yml
+++ b/.github/workflows/build-protoc.yml
@@ -1,6 +1,7 @@
 # yamllint disable rule:line-length
 ---
 name: Build protoc
+run-name: Build ${{ github.event.inputs.image }} with release tag ${{ github.event.inputs.release_tag }}
 
 # yamllint disable-line rule:truthy
 on:


### PR DESCRIPTION
<!-- Expectations for PRs: https://safetyculture.atlassian.net/wiki/spaces/ENG/pages/2881716914/RFC66+Pull+Request+Code+Review+Standards -->

## Summary

<!-- Short summary of what the PR does -->
Set the name of the workflow run based on the selected image (`protoc`, `protoc-go`, etc.)

## Problem description

<!-- Description of the problem being solved -->
Currently all workflow runs are named identically, making it hard to tell at a glance which run corresponds to which image build.

<img width="364" alt="image" src="https://github.com/SafetyCulture/protoc-docker/assets/660954/279a11f8-44aa-4518-b000-dbb8aaf06450">

## Pros/cons of approach implemented

## Checklist

<!-- Does it make sense for this PR to be of this size? If the PR is large, consider breaking it down into smaller incremental PRs. To check the box, put an `x` in the box -->

- [x] Is this PR a reasonable size?

<!-- If this PR is part of a broader set of changes, please provide a deployment sequence that includes all relevant PRs, so that changes can be reverted in the right order if a rollback were required (e.g. as part of an incident mitigation). To check the box, put an `x` in the box -->

- [ ] List deployment sequence with all relevant PRs.
  - ...

<!-- Everyone merges their own PRs. Respond to reviewer feedback before merging. Try to avoid taking feedback personally. -->

---

**Code Review Guidelines** for Reviewers

- Try to review in a timely manner. Opinions/nitpicks should not be blockers. Pair on a call for non-trivial feedback.
- Overall design and approach should follow established patterns. Don't try to make the PR perfect.
- Try to identify edge cases, race conditions, over-engineering, lack of test coverage and complexity.
- If you don't feel qualified to review the code, pass it on to someone who is.
