### PR TITLE
FG-6522: Bump protoc-go builder to golang:1.26.4-alpine

### DIFF
--- a/protoc-go/Dockerfile
+++ b/protoc-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0-alpine as builder
+FROM golang:1.26.4-alpine as builder
 
 ENV S12_PROTO_VERSION 1.39.0
 


### PR DESCRIPTION
## What
Bumps the `protoc-go` builder base image:
- `protoc-go/Dockerfile`: `FROM golang:1.24.0-alpine` → `golang:1.26.4-alpine`

## Why
[FG-6522](https://safetyculture.atlassian.net/browse/FG-6522). The `Build protoc` workflow fails on `protoc-go` at the Docker build step because tools installed by `build.sh` outgrew the builder's Go version (`GOTOOLCHAIN=local`, so Go won't auto-fetch a newer toolchain):

- `protoc-gen-workato@latest` requires **Go ≥ 1.25.0**
- `protoc-gen-govalidator@v1.39.0` (s12-proto v1.39.0, `go.mod`: `go 1.26`) requires **Go ≥ 1.26** ← binding constraint

```
s12-proto@v1.39.0 requires go >= 1.26 (running go 1.25.0; GOTOOLCHAIN=local)
RUN /src/build.sh -> exit code 1
```

Pre-existing breakage (last green `main` run: 2026-04-09), surfaced by [FG-6455 / #189](https://github.com/SafetyCulture/protoc-docker/pull/189) whose `protoc-go:3.27.0` image consequently did not publish. Only `protoc-go` has a `golang` builder, so the fix is scoped to it.

## After merge
The `Build protoc` Action on `main` should go green for `protoc-go` and publish `ghcr.io/safetyculture/protoc-go:3.27.0` (with `S12_PROTO_VERSION=1.39.0`), unblocking FG-6456 (APISchema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FG-6522]: https://safetyculture.atlassian.net/browse/FG-6522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ